### PR TITLE
fix: add typescript to readme + refactor readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # eslint-disable-snippets
 Includes snippets for ignoring; a block, the current line, or the next line.
 
-1. Start typing `eslint-disable` in a javascript, javascriptreact, or jsx file to trigger the snippet autocomplete.
+1. Start typing `eslint-disable` in a javascript `.js`, javascriptreact `.jsx`, typescript `.ts` or typescriptreact `.tsx` file to trigger the snippet autocomplete.
 1. Type the rule you want to disable or leave empty to disable all rules.
 1. Press `tab` to drop your cursor at a helpful position.
 1. Press `option+↓` to move the current line down. This is useful if you are wrapping a block of


### PR DESCRIPTION
Typescript users could be misguided with previous readme